### PR TITLE
Update for gnome shell 42

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -103,6 +103,7 @@ class TimeWarriorIndicator extends PanelMenu.Button {
 
   _currentActivity () {
 		let [res, out, err, status] = GLib.spawn_command_line_sync(TIMEWACT);
+        let response;
 		if (out == 1) {
 	    response = this._fetchActivity();
 		} else {
@@ -113,25 +114,26 @@ class TimeWarriorIndicator extends PanelMenu.Button {
 
   _fetchActivity () {
     let [res, out, err, status] = GLib.spawn_command_line_sync(TIMEWJSON);
-		info = JSON.parse(out);
+		let info = JSON.parse(out);
+        let tags;
 
 		if ("tags" in info)
 			tags = info.tags.sort(function (a, b) { return b.length - a.length; });
 		else
 			tags = [TAG_DEFAULT];
-		start = this._parseDate(info.start);
-		now = new Date().getTime();
-		miliseconds = now-start.getTime();
-		duration = new Date(miliseconds);
+		let start = this._parseDate(info.start);
+		let now = new Date().getTime();
+		let miliseconds = now-start.getTime();
+		let duration = new Date(miliseconds);
 
-		activity = tags[0];
+		let activity = tags[0];
 		if (tags[0].length > TAG_LIMIT) {
 			activity = activity.slice(0,TAG_LIMIT).concat('...');
 		}
 
-		hours = this._zeroPad(duration.getUTCHours());
-		minutes = this._zeroPad(duration.getUTCMinutes());
-		seconds = this._zeroPad(duration.getUTCSeconds());
+		let hours = this._zeroPad(duration.getUTCHours());
+		let minutes = this._zeroPad(duration.getUTCMinutes());
+		let seconds = this._zeroPad(duration.getUTCSeconds());
 		
 		let [sres, sout, serr, sstatus] = GLib.spawn_command_line_sync(TIMEW+ " s");
 		let lines = sout.toString().split(/\n/);
@@ -141,8 +143,8 @@ class TimeWarriorIndicator extends PanelMenu.Button {
   }
 
 	_zeroPad (num) {
-		snum = String(num);
-		lng = snum.length;
+		let snum = String(num);
+		let lng = snum.length;
 		if (lng==1) {
 			snum = String(0).concat(snum);
 		}

--- a/extension.js
+++ b/extension.js
@@ -41,12 +41,11 @@ let TAG_DEFAULT = "Work";
 let INTERVAL = 10;
 let TAG_LIMIT = 20;
 
-const TimeWarriorIndicator = new Lang.Class({
-  Name: 'TimeWarriorIndicator', Extends: PanelMenu.Button,
+const TimeWarriorIndicator = GObject.registerClass(
+class TimeWarriorIndicator extends PanelMenu.Button {
+  _init () {
+    super._init(0.0, _('TimeWarrior Indicator'));
 
-  _init: function()
-  {
-    this.parent(0.0, 'TimeWarrior Indicator', false);
     this.label = new St.Label({
       text: "No activity",
       y_align: Clutter.ActorAlign.CENTER
@@ -79,9 +78,9 @@ const TimeWarriorIndicator = new Lang.Class({
 		this._settings = Utils.getSettings();
 		this._settingsChangedId = this._settings.connect('changed', Lang.bind(this, this._applySettings));
 		this._applySettings();
-  },
+  }
 
-  _refresh: function() {
+  _refresh () {
     let v = this._currentActivity();
     if (v == null) {
     	this.label.set_text('No activity');
@@ -93,16 +92,16 @@ const TimeWarriorIndicator = new Lang.Class({
     this._removeTimeout();
     this._timeout = Mainloop.timeout_add_seconds(INTERVAL, Lang.bind(this, this._refresh));
     return true;
-  },
+  }
 
-  _removeTimeout: function() {
+  _removeTimeout () {
     if (this._timeout) {
       Mainloop.source_remove(this._timeout);
       this._timeout = null;
     }
-  },
+  }
 
-  _currentActivity: function() {
+  _currentActivity () {
 		let [res, out, err, status] = GLib.spawn_command_line_sync(TIMEWACT);
 		if (out == 1) {
 	    response = this._fetchActivity();
@@ -110,9 +109,9 @@ const TimeWarriorIndicator = new Lang.Class({
 			response = null; //'No activity';
 		}
 		return response;
-  },
+  }
 
-  _fetchActivity: function(){
+  _fetchActivity () {
     let [res, out, err, status] = GLib.spawn_command_line_sync(TIMEWJSON);
 		info = JSON.parse(out);
 
@@ -139,18 +138,18 @@ const TimeWarriorIndicator = new Lang.Class({
 		let total = lines[lines.length - 3].trim();
 
 		return activity.concat(' ',hours,':',minutes) + " ⌛ " + total;
-  },
+  }
 
-	_zeroPad: function(num){
+	_zeroPad (num) {
 		snum = String(num);
 		lng = snum.length;
 		if (lng==1) {
 			snum = String(0).concat(snum);
 		}
 		return snum;
-	},
+	}
 
-	_parseDate: function(input){
+	_parseDate (input) {
 		return new Date(Date.UTC(
 			parseInt(input.slice(0, 4), 10),
 			parseInt(input.slice(4, 6), 10) - 1,
@@ -159,32 +158,32 @@ const TimeWarriorIndicator = new Lang.Class({
 			parseInt(input.slice(11, 13), 10),
 			parseInt(input.slice(13,15), 10)
 		));
-	},
+	}
 
-	_stopTracking: function(){
+	_stopTracking () {
 		GLib.spawn_command_line_sync(TIMEW.concat(' stop'));
 		this._refresh();
-	},
+	}
 
-	_restartTracking: function(){
+	_restartTracking (){
 		GLib.spawn_command_line_sync(TIMEW.concat(' continue'));
 		this._refresh();
-	},
+	}
 
-	_openSettings: function () {
+	_openSettings  () {
 		Util.spawn([ "gnome-shell-extension-prefs", Me.uuid ]);
-	},
+	}
 
-	_applySettings: function() {
+	_applySettings () {
 		INTERVAL = this._settings.get_int('interval');
 		TIMEW = this._settings.get_string('timew-cmd');
 		TAG_LIMIT = this._settings.get_int('tag-length');
 		TAG_DEFAULT = "Work"; //this._settings.get_string('default-tag-text');
 		TIMEWACT = TIMEW.concat(' get dom.active');
 		TIMEWJSON = TIMEWACT.concat('.json');
-	},
+	}
 
-  stop: function(){
+  stop () {
     if (this._timeout)
       Mainloop.source_remove(this._timeout);
     this._timeout = undefined;

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {"name": "Timewarrior indicator",
   "description": "A simple panel, indicating the current activity as tracked from timewarrior",
   "uuid": "timewarrior-indicator@natsakis.com",
-  "shell-version": ["3.22.3","3.24.1"],
+  "shell-version": ["42.9"],
 	"url": "https://www.github.com/tassos/timewarrior-indicator",
-	"version": "3.1"
+	"version": "3.2"
 	}

--- a/prefs.js
+++ b/prefs.js
@@ -44,6 +44,5 @@ function buildPrefsWidget(){
 	settings.bind('tag-length' , buildable.get_object('tag-length') , 'value' , Gio.SettingsBindFlags.DEFAULT);
 	settings.bind('timew-cmd' , buildable.get_object('timew-cmd') , 'text' , Gio.SettingsBindFlags.DEFAULT);
 
-	box.show_all();
 	return box;
 };

--- a/prefs.xml
+++ b/prefs.xml
@@ -41,6 +41,7 @@
 
 			<child>
 				<object class="GtkBox">
+                <property name="orientation">vertical</property>
 				<property name="spacing">6</property>
 
 					<child>
@@ -100,6 +101,7 @@
 
 			<child>
 				<object class="GtkBox">
+                <property name="orientation">vertical</property>
 				<property name="spacing">6</property>
 
 					<child>

--- a/prefs.xml
+++ b/prefs.xml
@@ -35,13 +35,12 @@
 
 	<child> -->
 		<object class="GtkGrid" id="prefs_widget">
-			<property name="margin">18</property>
 			<property name="row-spacing">18</property>
 			<property name="row-homogeneous">false</property>
 			<property name="orientation">vertical</property>
 
 			<child>
-				<object class="GtkVBox">
+				<object class="GtkBox">
 				<property name="spacing">6</property>
 
 					<child>
@@ -62,7 +61,6 @@
 
 					<child>
 						<object class="GtkBox">
-							<property name="margin-left">12</property>
 							<property name="spacing">12</property>
 							<child>
 								<object class="GtkLabel">
@@ -81,7 +79,6 @@
 
 					<child>
 						<object class="GtkBox">
-							<property name="margin-left">12</property>
 							<property name="spacing">12</property>
 							<child>
 								<object class="GtkLabel">
@@ -102,7 +99,7 @@
 			</child>
 
 			<child>
-				<object class="GtkVBox">
+				<object class="GtkBox">
 				<property name="spacing">6</property>
 
 					<child>
@@ -117,7 +114,7 @@
 					</child>
 
 					<child>
-						<object class="GtkVBox">
+						<object class="GtkBox">
 							<property name="spacing">6</property>
 							<child>
 								<object class="GtkLabel">


### PR DESCRIPTION
This is a quick draft to make things compatible with gnome shell 42.9.

Note that this is my first time touching gnome extensions and I have very limited know how - please use this PR with caution.

I simply debugged the thing until it was working with my version of GNOME Shell. No idea which versions are actually compatible. But you can easily modify the `metadata.json` and add other GNOME Shell versions and test it there.

```
$ gnome-shell --version
GNOME Shell 42.9
```

What I had to do to get it working again:
- use the `GObject.registerClass()` function and use ES 6 class instead of an object for the indicator. I'm not entirely sure why this is necessary, I basically guessed it from the error message and a comparison to a working extension which I created from a template using the [gnome-extensions-tool](https://gjs.guide/extensions/development/creating.html#gnome-extensions-tool) by running `gnome-extensions create --interactive` and choosing "indicator" as template. There are also some hints regarding migrating shell classes [here](https://wiki.gnome.org/Projects/GnomeShell/Extensions/MigratingShellClasses).
- I had to declare all variables. No idea why. I just put a `let`  wherever necessary.
- I had to adapt the `prefs.xml`: I simply followed the error messages and got some inspiration by running `gtk4-builder-tool simplify --3to4 prefs.xml` - but the automatically converted xml did not show any dialog - just the empty window. Basically `margin` and `GtkVBox` has been removed as far as I understand.


Thanks to @petres for the help! :purple_heart: 

This may fix #7.